### PR TITLE
chore/include-media-in-app

### DIFF
--- a/scripts/includeMediaApp.sh
+++ b/scripts/includeMediaApp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+OUTPUT_FILE="$ROOT_DIR/app/src/constants/assetsMap.ts"
+BASE_PATH="$ROOT_DIR/app/assets/data"
+LEVELS=("N5" "N4")
+
+echo "export const assetsMap: Record<string, any> = {" > $OUTPUT_FILE
+
+for LVL in "${LEVELS[@]}"; do
+    LVL_DIR="$BASE_PATH/$LVL"
+    [ ! -d "$LVL_DIR" ] && continue
+
+    find "$LVL_DIR/audios" -name "*.mp3" 2>/dev/null | while read -r file; do
+        KEY=$(echo "$file" | sed "s|.*$LVL/audios/||")
+        CLEAN_PATH=$(echo "$file" | sed "s|^$ROOT_DIR/app/||")
+
+        REQ="../../$CLEAN_PATH"
+
+        echo "  \"$LVL$KEY\": require(\"$REQ\")," >> $OUTPUT_FILE
+    done
+
+    find "$LVL_DIR/images/JT4Y" -name "*.png" 2>/dev/null | while read -r file; do
+        SUB_PATH=$(echo "$file" | sed "s|.*JT4Y/||")
+
+        DIR_TYPE=$(dirname "$SUB_PATH")
+        FILENAME=$(basename "$file")
+        
+        KEY="$DIR_TYPE/$FILENAME"
+        REQ="../../assets/data/$LVL/images/JT4Y/$SUB_PATH"
+        
+        echo "  \"$LVL$KEY\": require(\"$REQ\")," >> $OUTPUT_FILE
+    done
+done
+
+echo "};" >> $OUTPUT_FILE

--- a/scripts/runMobile.sh
+++ b/scripts/runMobile.sh
@@ -56,6 +56,8 @@ cd "${ROOT_DIR}/app"
 echo "[mobile] Plataforma=${PLATFORM} Modo=${MODE} Flavor=${FLAVOR}"
 echo "[mobile] EXPO_PUBLIC_API_URL=${EXPO_PUBLIC_API_URL}"
 
+"${ROOT_DIR}/scripts/includeMediaApp.sh"
+
 if [[ "${MODE}" == "debug" ]]; then
   if [[ "${PLATFORM}" == "android" ]]; then
     npx expo start --android


### PR DESCRIPTION
Para facilitar o acesso aos arquivos de mídia estáticos pelo aplicativo, precisamos usar o `require` em todos eles com strings não-dinâmicas em nosso código React Native.

Por conta disso, agora temos, no repositório `app`, um arquivo que mapeia cada caminho de arquivo (conforme listado nas questões do banco de dados) para um `require` daquele arquivo específico.

**Quanto a este PR:**
Como o banco de dados pode sofrer alterações, toda vez que buildamos o aplicativo, geramos novamente tal arquivo para se adequar a versão atual do banco.